### PR TITLE
feat: get-clothes api 추가

### DIFF
--- a/src/controller/clothes/controller.ts
+++ b/src/controller/clothes/controller.ts
@@ -1,8 +1,10 @@
 import { RequestHandler } from 'express';
+import GetClothesReq from '../../type/getClothes/getClothes.req';
+import GetClothesRes from '../../type/getClothes/getClothes.res';
+import { BadRequestError, UnauthorizedError } from '../../util/customErrors';
 import ClothesService from '../../service/clothes.service';
 import CreateClothesReq from '../../type/clothes/createClothes.req';
 import CreateClothesRes from '../../type/clothes/createClothes.res';
-import { BadRequestError, UnauthorizedError } from '../../util/customErrors';
 import Category from '../../common/enum/category.enum';
 import Season from '../../common/enum/season.enum';
 import Status from '../../common/enum/status.enum';
@@ -51,6 +53,24 @@ export const createClothes: RequestHandler = async (req, res, next) => {
     res.json(creaetClothesRes);
   } catch (error) {
     console.log('error in createClothes :', error);
+    next(error);
+  }
+};
+
+export const getClothes: RequestHandler = async (req, res, next) => {
+  try {
+    const clothesId = Number(req.params.clothesId);
+    //const { clothesId } = req.body;
+
+    if (!clothesId) throw new BadRequestError('ClothesId is required.');
+
+    const ClothesId: GetClothesReq = { clothesId };
+
+    const getClothesRes: GetClothesRes =
+      await ClothesService.getClothes(ClothesId);
+
+    res.json(getClothesRes);
+  } catch (error) {
     next(error);
   }
 };

--- a/src/controller/clothes/controller.ts
+++ b/src/controller/clothes/controller.ts
@@ -60,14 +60,15 @@ export const createClothes: RequestHandler = async (req, res, next) => {
 export const getClothes: RequestHandler = async (req, res, next) => {
   try {
     const clothesId = Number(req.params.clothesId);
-    //const { clothesId } = req.body;
 
     if (!clothesId) throw new BadRequestError('ClothesId is required.');
 
     const ClothesId: GetClothesReq = { clothesId };
 
-    const getClothesRes: GetClothesRes =
-      await ClothesService.getClothes(ClothesId);
+    const getClothesRes: GetClothesRes = await ClothesService.getClothes(
+      ClothesId,
+      req.user ? req.user.id : null,
+    );
 
     res.json(getClothesRes);
   } catch (error) {

--- a/src/controller/clothes/router.ts
+++ b/src/controller/clothes/router.ts
@@ -1,8 +1,9 @@
 import { Router } from 'express';
-import { createClothes } from './controller';
+import { getClothes, createClothes } from './controller';
 
 const clothesRouter = Router();
 
 clothesRouter.post('/', createClothes);
+clothesRouter.get('/:clothesId', getClothes);
 
 export default clothesRouter;

--- a/src/repository/clothes.repository.ts
+++ b/src/repository/clothes.repository.ts
@@ -1,6 +1,16 @@
 import AppDataSource from '../config/dataSource';
 import Clothes from '../entity/clothes.entity';
+import { BadRequestError } from '../util/customErrors';
 
 const ClothesRepository = AppDataSource.getRepository(Clothes).extend({});
 
-export default ClothesRepository;
+const GetClothesRepository = AppDataSource.getRepository(Clothes).extend({
+  async findOneByClothesId(id: number): Promise<Clothes> {
+    return this.findOneBy({ id }).then((clothes) => {
+      if (!clothes) throw new BadRequestError('등록되어있지 않은 의류입니다.');
+      return clothes;
+    });
+  },
+});
+
+export { GetClothesRepository, ClothesRepository };

--- a/src/repository/clothes.repository.ts
+++ b/src/repository/clothes.repository.ts
@@ -2,9 +2,7 @@ import AppDataSource from '../config/dataSource';
 import Clothes from '../entity/clothes.entity';
 import { BadRequestError } from '../util/customErrors';
 
-const ClothesRepository = AppDataSource.getRepository(Clothes).extend({});
-
-const GetClothesRepository = AppDataSource.getRepository(Clothes).extend({
+const ClothesRepository = AppDataSource.getRepository(Clothes).extend({
   async findOneByClothesId(id: number): Promise<Clothes> {
     return this.findOneBy({ id }).then((clothes) => {
       if (!clothes) throw new BadRequestError('등록되어있지 않은 의류입니다.');
@@ -13,4 +11,4 @@ const GetClothesRepository = AppDataSource.getRepository(Clothes).extend({
   },
 });
 
-export { GetClothesRepository, ClothesRepository };
+export default ClothesRepository;

--- a/src/service/clothes.service.ts
+++ b/src/service/clothes.service.ts
@@ -1,9 +1,6 @@
 import Clothes from '../entity/clothes.entity';
 import CreateClothesReq from '../type/clothes/createClothes.req';
-import {
-  ClothesRepository,
-  GetClothesRepository,
-} from '../repository/clothes.repository';
+import ClothesRepository from '../repository/clothes.repository';
 import GetClothesReq from '../type/getClothes/getClothes.req';
 import GetClothesRes from '../type/getClothes/getClothes.res';
 import { ForbiddenError } from '../util/customErrors';
@@ -22,7 +19,7 @@ export default class ClothesService {
 
   static async getClothes(id: GetClothesReq): Promise<GetClothesRes> {
     const { clothesId } = id;
-    const clothes = await GetClothesRepository.findOneByClothesId(clothesId);
+    const clothes = await ClothesRepository.findOneByClothesId(clothesId);
 
     if (!clothes.isOpen) throw new ForbiddenError('공개되지 않은 옷입니다.');
 

--- a/src/service/clothes.service.ts
+++ b/src/service/clothes.service.ts
@@ -1,6 +1,12 @@
 import Clothes from '../entity/clothes.entity';
 import CreateClothesReq from '../type/clothes/createClothes.req';
-import ClothesRepository from '../repository/clothes.repository';
+import {
+  ClothesRepository,
+  GetClothesRepository,
+} from '../repository/clothes.repository';
+import GetClothesReq from '../type/getClothes/getClothes.req';
+import GetClothesRes from '../type/getClothes/getClothes.res';
+import { ForbiddenError } from '../util/customErrors';
 
 export default class ClothesService {
   static async createClothes(clothesInfo: CreateClothesReq): Promise<Clothes> {
@@ -12,5 +18,15 @@ export default class ClothesService {
     } catch (error) {
       throw new Error(`error in createClothes : ${error}`);
     }
+  }
+
+  static async getClothes(id: GetClothesReq): Promise<GetClothesRes> {
+    const { clothesId } = id;
+    const clothes = await GetClothesRepository.findOneByClothesId(clothesId);
+
+    if (!clothes.isOpen) throw new ForbiddenError('공개되지 않은 옷입니다.');
+
+    const getClothesRes: GetClothesRes = clothes;
+    return getClothesRes;
   }
 }

--- a/src/service/clothes.service.ts
+++ b/src/service/clothes.service.ts
@@ -17,13 +17,16 @@ export default class ClothesService {
     }
   }
 
-  static async getClothes(id: GetClothesReq): Promise<GetClothesRes> {
+  static async getClothes(
+    id: GetClothesReq,
+    userId: number | null,
+  ): Promise<GetClothesRes> {
     const { clothesId } = id;
     const clothes = await ClothesRepository.findOneByClothesId(clothesId);
 
-    if (!clothes.isOpen) throw new ForbiddenError('공개되지 않은 옷입니다.');
-
-    const getClothesRes: GetClothesRes = clothes;
-    return getClothesRes;
+    if (clothes.isOpen || (userId && userId === clothes.closet.owner.id)) {
+      const getClothesRes: GetClothesRes = clothes;
+      return getClothesRes;
+    } else throw new ForbiddenError('공개되지 않은 옷입니다.');
   }
 }

--- a/src/type/getClothes/getClothes.req.ts
+++ b/src/type/getClothes/getClothes.req.ts
@@ -1,0 +1,3 @@
+export default interface GetClothesReq {
+  clothesId: number;
+}

--- a/src/type/getClothes/getClothes.res.ts
+++ b/src/type/getClothes/getClothes.res.ts
@@ -1,0 +1,16 @@
+import Closet from '../../entity/closet.entity';
+import Category from '../../common/enum/category.enum';
+import Season from '../../common/enum/season.enum';
+import Status from '../../common/enum/status.enum';
+
+export default interface GetClothesRes {
+  id?: number;
+  closet: Closet;
+  category?: Category;
+  season?: Season;
+  status: Status;
+  isOpen: boolean;
+  name: string;
+  tag?: string;
+  image?: string;
+}


### PR DESCRIPTION
옷 상세 가져오기 API 추가하였습니다.
getClothes/controller.ts 16-17행에서 Clothes entity의 id가 ?로 설정되어있어 undefined 값때문에 compatible하지 않아 할당할 수 없다고 하여 clothes.entity.ts를 id? = number; -> id! = number;로 변경하였습니다.

파일을 clothes에 병합해야할 것 같은데 우선은 getClothes로 모두 분리해두었습니다.