### PR TITLE
feat: add delete-closet-api

### DIFF
--- a/src/controller/closet/controller.ts
+++ b/src/controller/closet/controller.ts
@@ -87,3 +87,23 @@ export const modifyCloset: RequestHandler = async (req, res, next) => {
     next(error);
   }
 };
+
+export const deleteCloset: RequestHandler = async (req, res, next) => {
+  try {
+    const closetId = Number(req.params.closetId);
+
+    if (!req.user) {
+      throw new UnauthorizedError('로그인이 필요한 기능입니다.');
+    }
+    const { id } = req.user as LoginUser;
+
+    await ClosetService.deleteCloset(closetId, id);
+
+    const message: DefaultRes = {
+      message: '옷장이 삭제되었습니다.',
+    };
+    res.json(message);
+  } catch (error) {
+    next(error);
+  }
+};

--- a/src/controller/closet/router.ts
+++ b/src/controller/closet/router.ts
@@ -2,6 +2,7 @@ import { Router } from 'express';
 import { getClosetList, postCloset } from './controller';
 import { getCloset } from './controller';
 import { modifyCloset } from './controller';
+import { deleteCloset } from './controller';
 
 const closetRouter = Router();
 
@@ -9,5 +10,6 @@ closetRouter.post('/', postCloset);
 closetRouter.get('/', getClosetList);
 closetRouter.get('/:closetId', getCloset);
 closetRouter.put('/:closetId', modifyCloset);
+closetRouter.delete('/:closetId', deleteCloset);
 
 export default closetRouter;

--- a/src/repository/clothes.repository.ts
+++ b/src/repository/clothes.repository.ts
@@ -1,7 +1,6 @@
 import AppDataSource from '../config/dataSource';
 import Clothes from '../entity/clothes.entity';
 import { BadRequestError } from '../util/customErrors';
-import { UpdateResult } from 'typeorm';
 
 const ClothesRepository = AppDataSource.getRepository(Clothes).extend({
   async findOneByClothesId(id: number): Promise<Clothes> {
@@ -30,14 +29,6 @@ const ClothesRepository = AppDataSource.getRepository(Clothes).extend({
         { id: closetId, closet: { owner: { id: userId } } },
       ],
     });
-  },
-
-  async updateAllClosetId(closetId: number): Promise<UpdateResult> {
-    return AppDataSource.createQueryBuilder()
-      .update(Clothes)
-      .set({ closet: null })
-      .where({ closet: { id: closetId } })
-      .execute();
   },
 });
 

--- a/src/repository/clothes.repository.ts
+++ b/src/repository/clothes.repository.ts
@@ -1,6 +1,7 @@
 import AppDataSource from '../config/dataSource';
 import Clothes from '../entity/clothes.entity';
 import { BadRequestError } from '../util/customErrors';
+import { UpdateResult } from 'typeorm';
 
 const ClothesRepository = AppDataSource.getRepository(Clothes).extend({
   async findOneByClothesId(id: number): Promise<Clothes> {
@@ -13,7 +14,7 @@ const ClothesRepository = AppDataSource.getRepository(Clothes).extend({
     });
   },
 
-  async findByClosetId(closetId: number): Promise<Clothes[]> {
+  async findOpenByClosetId(closetId: number): Promise<Clothes[]> {
     return this.find({
       where: { id: closetId, isOpen: true },
     });
@@ -29,6 +30,14 @@ const ClothesRepository = AppDataSource.getRepository(Clothes).extend({
         { id: closetId, closet: { owner: { id: userId } } },
       ],
     });
+  },
+
+  async updateAllClosetId(closetId: number): Promise<UpdateResult> {
+    return AppDataSource.createQueryBuilder()
+      .update(Clothes)
+      .set({ closet: null })
+      .where({ closet: { id: closetId } })
+      .execute();
   },
 });
 

--- a/src/service/closet.service.ts
+++ b/src/service/closet.service.ts
@@ -88,7 +88,10 @@ export default class ClosetService {
     if (ownerId != userId)
       throw new BadRequestError('본인의 옷장만 삭제할 수 있습니다.');
 
-    await ClothesRepository.updateAllClosetId(closetId);
+    await ClothesRepository.update(
+      { closet: { id: closetId } },
+      { closet: undefined },
+    );
 
     return await ClosetRepository.softDelete(closetId);
   }

--- a/src/service/closet.service.ts
+++ b/src/service/closet.service.ts
@@ -79,4 +79,15 @@ export default class ClosetService {
 
     return await ClosetRepository.update(closet.id, { name: closet.name });
   }
+
+  static async deleteCloset(
+    closetId: number,
+    userId: number,
+  ): Promise<UpdateResult> {
+    const ownerId = await ClosetRepository.getOwnerId(closetId);
+    if (ownerId != userId)
+      throw new BadRequestError('본인의 옷장만 삭제할 수 있습니다.');
+
+    return await ClosetRepository.softDelete(closetId);
+  }
 }

--- a/src/service/closet.service.ts
+++ b/src/service/closet.service.ts
@@ -18,7 +18,7 @@ export default class ClosetService {
   ): Promise<getClosetRes> {
     const closet: Closet = await ClosetRepository.findOneByClosetId(closetId);
     const clothes: Clothes[] = !userId
-      ? await ClothesRepository.findByClosetId(closetId)
+      ? await ClothesRepository.findOpenByClosetId(closetId)
       : await ClothesRepository.findVisibleByClosetId(closetId, userId);
 
     const clothesInfo: Array<getClosetClothes> = clothes.map((clothes) => {
@@ -87,6 +87,8 @@ export default class ClosetService {
     const ownerId = await ClosetRepository.getOwnerId(closetId);
     if (ownerId != userId)
       throw new BadRequestError('본인의 옷장만 삭제할 수 있습니다.');
+
+    await ClothesRepository.updateAllClosetId(closetId);
 
     return await ClosetRepository.softDelete(closetId);
   }


### PR DESCRIPTION
옷장 삭제 api입니다.

param으로 closetid를 받고 삭제가 정상적으로 이루어지면 삭제 성공 메세지를 응답합니다.

테스트 화면입니다.
![image](https://github.com/KWEBofficial/stylevillage-server/assets/129672066/afc35022-ba46-4d3e-86e4-20c34a51eb4f)

추가로, 존재하지 않는 closet의 Id를 param으로 전달할 가능성이 있는지 궁금합니다. 만약 그런 경우가 존재한다면 closet 존재 여부를 확인하는 과정이 필요할 것 같습니다. -> getOwnerId 레포지토리에서 처리되어 있어서 괜찮을 것 같습니다!